### PR TITLE
feat: allow node-exporter to be deployed without nodeSelector

### DIFF
--- a/prometheus-node-exporter/Chart.yaml
+++ b/prometheus-node-exporter/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 appVersion: v0.18.1
 description: OpenStack-Helm Node Exporter for Prometheus
 name: prometheus-node-exporter
-version: 0.1.5
+version: 0.1.5-beskar-cloud-1
 home: https://github.com/prometheus/node_exporter
 sources:
   - https://github.com/prometheus/node_exporter

--- a/prometheus-node-exporter/templates/daemonset.yaml
+++ b/prometheus-node-exporter/templates/daemonset.yaml
@@ -60,8 +60,10 @@ spec:
 {{ if .Values.pod.tolerations.node_exporter.enabled }}
 {{ tuple $envAll "node_exporter" | include "helm-toolkit.snippets.kubernetes_tolerations" | indent 6 }}
 {{ else }}
+{{ if .Values.labels.node_exporter }}
       nodeSelector:
         {{ .Values.labels.node_exporter.node_selector_key }}: {{ .Values.labels.node_exporter.node_selector_value | quote }}
+{{ end }}
 {{ end }}
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
feat: allow node-exporter to be deployed without nodeSelector (.Values.labels.node_exporter == null)

Some monitoring deployments prefer running base monitoring containers (as node-exporter) on all nodes i.e. w/o specific labels.